### PR TITLE
Better support for structures and multi-site setups

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "trendyminds/isolate",
     "description": "Restrict your Craft CMS users on a per-entry basis",
     "type": "craft-plugin",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "keywords": [
         "permissions",
         "entry permission",

--- a/src/assetbundles/indexcpsection/dist/css/Index.css
+++ b/src/assetbundles/indexcpsection/dist/css/Index.css
@@ -38,6 +38,10 @@
   padding-left: 3px;
 }
 
+.isolate__section-check-all {
+  margin-left: 20px;
+}
+
 .isolate__empty-frame {
   position: relative;
   top: 50%;

--- a/src/assetbundles/indexcpsection/dist/js/Index.js
+++ b/src/assetbundles/indexcpsection/dist/js/Index.js
@@ -13,13 +13,14 @@
 class PermissionGroup {
   constructor($group) {
     this.$group = $group;
-    this.groupName = this.$group.dataset.isolateGroup;
     this.$toggle = this.$group.querySelector("[data-toggle]");
     this.$label = this.$group.querySelector("[data-toggle-label]");
+    this.$checkAll = this.$group.querySelector("[data-check-all-label]");
     this.$checkboxes = this.$group.querySelectorAll("input");
     this.enabled = (this.$group.dataset.enabled == "true");
 
     this.handleToggle = this.handleToggle.bind(this);
+    this.handleCheckAll = this.handleCheckAll.bind(this);
 
     this.init();
     this.events();
@@ -35,6 +36,7 @@ class PermissionGroup {
 
   events() {
     this.$toggle.addEventListener("click", this.handleToggle);
+    this.$checkAll.addEventListener("click", this.handleCheckAll);
   }
 
   handleToggle(ev) {
@@ -47,15 +49,20 @@ class PermissionGroup {
     }
   }
 
+  handleCheckAll(ev) {
+    ev.preventDefault();
+    this.$checkboxes.forEach($checkbox => $checkbox.checked = true);
+  }
+
   enable() {
     this.enabled = true;
-    this.$checkboxes.forEach($checkbox => $checkbox.removeAttribute("checked"));
+    this.$checkboxes.forEach($checkbox => $checkbox.checked = false);
     this.enableCheckboxes();
   }
 
   disable() {
     this.enabled = false;
-    this.$checkboxes.forEach($checkbox => $checkbox.setAttribute("checked", "checked"));
+    this.$checkboxes.forEach($checkbox => $checkbox.checked = true);
     this.disableCheckboxes();
   }
 

--- a/src/services/IsolateService.php
+++ b/src/services/IsolateService.php
@@ -135,8 +135,8 @@ class IsolateService extends Component
      * Returns the isolated entries for a given user
      *
      * @param integer $userId
-     * @param string $sectionHandle
-     * @return Entry
+     * @param integer $sectionId
+     * @return IsolateRecord[]
      */
     public function getIsolatedEntries(int $userId, int $sectionId = null)
     {
@@ -150,8 +150,11 @@ class IsolateService extends Component
      * Modifies database record of an isolated user (adds/edit/removes)
      *
      * @param integer $userId
+     * @param integer $sectionId
      * @param array $entries
      * @return void
+     * @throws \Throwable
+     * @throws \yii\db\StaleObjectException
      */
     public function modifyRecords(int $userId, int $sectionId, array $entries)
     {
@@ -242,7 +245,7 @@ class IsolateService extends Component
      *
      * @param integer $userId
      * @param integer $sectionId
-     * @return void
+     * @return array
      */
     public function getUserEntriesIds(int $userId, int $sectionId = null)
     {
@@ -294,7 +297,8 @@ class IsolateService extends Component
      *
      * @param integer $userId
      * @param integer $sectionId
-     * @return void
+     * @param int $limit
+     * @return array
      */
     public function getUserEntries(int $userId, int $sectionId = null, int $limit = 50)
     {
@@ -311,7 +315,8 @@ class IsolateService extends Component
      *
      * @param integer $userId
      * @param string $path
-     * @return void
+     * @return bool
+     * @throws ForbiddenHttpException
      */
     public function verifyIsolatedUserAccess(int $userId, string $path)
     {

--- a/src/templates/users/_user.twig
+++ b/src/templates/users/_user.twig
@@ -72,31 +72,18 @@
       </div>
 
       {% if isStructure %}
-        <div class="tableview">
-          <table class="data fullwidth">
-            <thead>
-              <tr>
-                <td scope="col">Title</td>
-              </tr>
-            </thead>
-            <tbody>
-              {% for entry in entries %}
-                {% set indent = 8 + (entry.level - 1) * 35 %}
-                <tr>
-                  <td style="padding-left: {{ indent }}px;">
-                    {{ forms.checkbox({
-                      label: entry.title,
-                      value: entry.id,
-                      name: "entries[]",
-                      disabled: true,
-                      checked: entry.id in isolatedEntries
-                    }) }}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+        {% for entry in entries %}
+          {% set indent = 8 + (entry.level - 1) * 35 %}
+          <div style="padding-left: {{ indent }}px;">
+            {{ forms.checkbox({
+              label: entry.title,
+              value: entry.id,
+              name: "entries[]",
+              disabled: true,
+              checked: entry.id in isolatedEntries
+            }) }}
+          </div>
+        {% endfor %}
       {% else %}
         {% set options = [] %}
         {% for entry in entries %}

--- a/src/templates/users/_user.twig
+++ b/src/templates/users/_user.twig
@@ -41,50 +41,78 @@
 {% endblock %}
 
 {% set content %}
-  {% set isolatedEntries = [] %}
-  {% set entries = [] %}
-
   {% if section is defined and section %}
+    {% set isolatedEntries = [] %}
+    {% set entries = [] %}
+    {% set isStructure = craft.isolate.isStructure(section.id) %}
+
     {% for record in craft.isolate.getIsolatedEntries(user.id, section.id) %}
       {% set isolatedEntries = isolatedEntries | merge([record.entryId]) %}
     {% endfor %}
-  {% endif %}
 
-  {% if section is defined and section %}
-    {% set entries = craft.isolate.getAllEntries(section.id) %}
-  {% endif %}
+    {% if isStructure %}
+      {% set entries = craft.isolate.getStructureEntries(section.id) %}
+    {% else %}
+      {% set entries = craft.isolate.getAllEntries(section.id) %}
+    {% endif %}
 
-  {% if section is defined and section %}
     <input type="hidden" name="action" value="isolate/users/save">
     <input type="hidden" name="userId" value="{{user.id}}">
     <input type="hidden" name="sectionId" value="{{section.id}}">
-  {% endif %}
 
-  {% if section is defined and section %}
     <section class="isolate__section" data-isolate-group="{{section.handle}}" data-enabled="{{isolatedEntries | length > 0 ? 'true' : 'false'}}">
       <div class="isolate__section-header">
         <h2 class="isolate__section-name">{{section.name}}</h2>
         <a href="#" class="isolate__section-toggle icon" data-toggle="manage-{{section.handle}}">
           <span data-toggle-label></span>
         </a>
+        <a href="#" class="isolate__section-toggle icon add isolate__section-check-all">
+          <span data-check-all-label>Check all</span>
+        </a>
       </div>
 
-      {% set options = [] %}
-
-      {% for entry in entries %}
-        {% set options = options | merge([{
+      {% if isStructure %}
+        <div class="tableview">
+          <table class="data fullwidth">
+            <thead>
+              <tr>
+                <td scope="col">Title</td>
+              </tr>
+            </thead>
+            <tbody>
+              {% for entry in entries %}
+                {% set indent = 8 + (entry.level - 1) * 35 %}
+                <tr>
+                  <td style="padding-left: {{ indent }}px;">
+                    {{ forms.checkbox({
+                      label: entry.title,
+                      value: entry.id,
+                      name: "entries[]",
+                      disabled: true,
+                      checked: entry.id in isolatedEntries
+                    }) }}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        {% set options = [] %}
+        {% for entry in entries %}
+          {% set options = options | merge([{
             label: entry.title,
             value: entry.id,
             name: "entries[]",
             disabled: true,
             checked: entry.id in isolatedEntries
           }])
-        %}
-      {% endfor %}
-
-      <div class="manage-{{section.handle}}">
-        {{forms.checkboxGroupField({ options: options })}}
-      </div>
+          %}
+        {% endfor %}
+        <div class="manage-{{section.handle}}">
+          {{forms.checkboxGroupField({ options: options })}}
+        </div>
+      {% endif %}
     </section>
   {% endif %}
 

--- a/src/variables/IsolateVariable.php
+++ b/src/variables/IsolateVariable.php
@@ -47,4 +47,14 @@ class IsolateVariable
     {
         return Isolate::$plugin->isolateService->getAllEntries($sectionId);
     }
+
+    public function isStructure(int $sectionId)
+    {
+        return Isolate::$plugin->isolateService->isStructure($sectionId);
+    }
+
+    public function getStructureEntries(int $sectionId)
+    {
+        return Isolate::$plugin->isolateService->getStructureEntries($sectionId);
+    }
 }


### PR DESCRIPTION
I added better support for structures and multi-site setups.

In the old version if you created an article that belonged on 2 sites (German and English for example) you would get 2 checkboxes that pointed to the same entry ID, I now merge the titles with a pipe and display only one checkbox. Ideally the plugin would allow separate assignment per page but I didn't have time to modify the data model accordingly. 

I also added support for structures so the entries are displayed in the correct order and are indented:
https://i.imgur.com/BuTWlFW.png

I also fixed some typos in the PHPdoc and added a "select all" button that allows you to select all checkboxes and then just remove a couple you don't like by hand. This wasn't possible before because the plugin would grey out the checkboxes if you chose to allow all entries. 