### PR TITLE
Make plugin work again on craft 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Release Notes for Isolate
 
-## 1.1.2 - 2019-05-09
+## 1.1.3 - 2020-03-09
 
 ### Fixed
-- Redirect users attempting to access the entry listing panel instead of throwing an error. This prevents an exception from being thrown if a user saves an entry and is redirected back to the entry listing area
+- Makes the plugin run on latest version of craft (3.4)
+- Fixes Permission registration event
+
+### Changed
+- Added owner to column of entries display table
 
 ## 1.1.1 - 2019-05-01
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "trendyminds/isolate",
     "description": "Restrict your Craft CMS users on a per-entry basis",
     "type": "craft-plugin",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "keywords": [
         "permissions",
         "entry permission",

--- a/src/Isolate.php
+++ b/src/Isolate.php
@@ -103,9 +103,10 @@ class Isolate extends Plugin
             UserPermissions::class,
             UserPermissions::EVENT_REGISTER_PERMISSIONS,
             function(RegisterUserPermissionsEvent $event) {
-                $event->permissions["General"]["accessCp"]["nested"]["accessPlugin-isolate"]["nested"] = [
+                // TODO: This is not nested where it originally was, but it is working as intended.
+                $event->permissions['Isolate'] = [
                     'isolate:assign' => [
-                        'label' => 'Assign permissions',
+                        'label' => 'Assign Permissions'
                     ],
                 ];
             }

--- a/src/services/IsolateService.php
+++ b/src/services/IsolateService.php
@@ -10,6 +10,9 @@
 
 namespace trendyminds\isolate\services;
 
+use craft\elements\db\ElementQuery;
+use craft\elements\db\ElementQueryInterface;
+use craft\elements\db\EntryQuery;
 use craft\models\Section;
 use craft\services\Sections;
 use craft\services\Structures;
@@ -378,7 +381,7 @@ class IsolateService extends Component
      * @param integer $userId
      * @param integer $sectionId
      * @param int $limit
-     * @return array
+     * @return ElementQuery|ElementQueryInterface|EntryQuery
      */
     public function getUserEntries(int $userId, int $sectionId = null, int $limit = 50)
     {

--- a/src/templates/dashboard/index.twig
+++ b/src/templates/dashboard/index.twig
@@ -33,7 +33,7 @@
 {% endblock %}
 
 {% block sidebar %}
-  <nav>
+    <nav>
     <ul>
       {% for type, sections in sectionGroup %}
         {% if type == "single" %}
@@ -68,6 +68,7 @@
         <tr>
           <th>Title</th>
           <th>Post Date</th>
+          <th>Owner</th>
           <th data-icon="world"></th>
         </tr>
       </thead>
@@ -81,6 +82,7 @@
               <a href="{{entry.cpEditUrl}}">{{entry.title}}</a>
             </td>
             <td>{{entry.postDate | date("n/j/Y")}}</td>
+            <td>{{ entry.author }}</td>
             <td>
               {% if entry.url %}
                 <a href="{{entry.url}}" target="_blank" data-icon="world"></a>


### PR DESCRIPTION
This small change will make the plugin work with craft 3.4.
It might not list the permissions in the correct nested array but it shows the correct isolate:assign at the bottom.

Its not tested all the way trough, I simply needed this for my own use and id like to raise this PR incase someone else needs the same or wants to help contribute.