### PR TITLE
Fix bug when array is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Isolate
 
+## 1.4.2 - 2020-10-28
+
+### Fixed
+- Fix error that occurred if an Isolated user is accessing the control panel homepage and `$segments` contains no array items. ([#24](https://github.com/trendyminds/isolate/pull/24))
+
 ## 1.4.1 - 2020-10-26
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "trendyminds/isolate",
     "description": "Restrict your Craft CMS users on a per-entry basis",
     "type": "craft-plugin",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "keywords": [
         "permissions",
         "entry permission",

--- a/src/services/IsolateService.php
+++ b/src/services/IsolateService.php
@@ -380,7 +380,7 @@ class IsolateService extends Component
         $segments = Craft::$app->request->getSegments();
 
         // If a user is attempting to edit a specific entry (but not create a new one)
-        if ($segments[0] === "entries" && isset($segments[2]) && (!Craft::$app->request->getParam('fresh') && $segments[2] !== "new"))
+        if (count($segments) && $segments[0] === "entries" && isset($segments[2]) && (!Craft::$app->request->getParam('fresh') && $segments[2] !== "new"))
         {
             // Get the ID of the entry a user is accessing
             preg_match("/^\d*/", $segments[2], $matches);
@@ -397,7 +397,7 @@ class IsolateService extends Component
 
         // Deny isolated user access to the entries area by redirecting back to dashboard
         // Redirecting because saving an entry often takes a user back to the entries listing
-        if ($segments[0] === "entries" && !isset($segments[2]))
+        if (count($segments) && $segments[0] === "entries" && !isset($segments[2]))
         {
             $url = "isolate";
 


### PR DESCRIPTION
Fixes #24 where an error occurred if an Isolated user is accessing the control panel homepage and `$segments` contains no array items.