### PR TITLE
Fix Isolate not working with Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Isolate
 
+## 1.4.3 - 2021-11-10
+
+### Fixed
+- Fix error when displaying entries an isolated user has access to when using a Postgres database ([#41](https://github.com/trendyminds/isolate/pull/41))
+
 ## 1.4.3 - 2020-11-16
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "trendyminds/isolate",
     "description": "Restrict your Craft CMS users on a per-entry basis",
     "type": "craft-plugin",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "keywords": [
         "permissions",
         "entry permission",

--- a/src/services/IsolateService.php
+++ b/src/services/IsolateService.php
@@ -336,7 +336,7 @@ class IsolateService extends Component
         // We need to display all of these
         $sectionEntries = $secQuery->select(["ent.id"])
             ->from("{{%entries}} ent")
-            ->leftJoin("{{%sections}} sec", "ent.sectionId=sec.id")
+            ->leftJoin("{{%sections}} sec", "{{ent}}.{{sectionId}} = {{sec}}.{{id}}")
             ->filterWhere(["ent.sectionId" => $sectionId])
             ->andFilterWhere(["not", ["ent.sectionId" => $isolatedSections]])
             ->all();


### PR DESCRIPTION
Isolate previously crashed on Postgres. This PR escapes the table and column names, which fixes the crash.